### PR TITLE
Add health-check for DB connectivity and HTTP/S status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,12 @@ RUN rm -f /etc/nginx/conf.d/default.conf
 EXPOSE 80
 EXPOSE 443
 
+# Add health check for database connectivity and HTTP status
+COPY healthcheck.sh /healthcheck.sh
+RUN chmod +x /healthcheck.sh
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD /healthcheck.sh
+
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# 1. Database Connectivity Check
+# Returns exit code 2 if database connection fails
+php -r '
+if (file_exists("/var/www/html/wp-config.php")) {
+    include "/var/www/html/wp-config.php";
+    $conn = @new mysqli(DB_HOST, DB_USER, DB_PASSWORD, DB_NAME);
+    if ($conn->connect_error) {
+        exit(2);
+    }
+    exit(0);
+}
+# If wp-config.php doesn\'t exist yet, we consider it "not ready" (generic failure 1) rather than DB failure (2).
+exit(1);
+'
+PHP_EXIT=$?
+if [ $PHP_EXIT -eq 2 ]; then
+    exit 2
+elif [ $PHP_EXIT -ne 0 ]; then
+    exit 1
+fi
+
+# 2. HTTP/HTTPS Status Check
+# Returns exit code 1 if the web server is not reachable or returns an error status
+HOST=${DOMAIN_NAME:-localhost}
+URL="http://127.0.0.1/wp-login.php"
+CURL_OPTS="-f -L -o /dev/null -H \"Host: $HOST\""
+
+if [ "$HTTPS_ENABLED" = "true" ]; then
+    URL="https://127.0.0.1/wp-login.php"
+    # -k to allow self-signed certificates (common in internal/testing setups)
+    CURL_OPTS="$CURL_OPTS -k"
+fi
+
+# We use eval to correctly parse the quoted arguments in CURL_OPTS
+eval curl $CURL_OPTS "$URL" || exit 1
+
+exit 0


### PR DESCRIPTION
Implements #16.

This PR adds a `HEALTHCHECK` instruction to the Dockerfile and a supporting `healthcheck.sh` script.

### Features:
- **Database Check:** Verifies connection to the database using credentials from `wp-config.php`. Returns exit code `2` on failure.
- **HTTP/S Status Check:** Verifies that the web server is reachable via `curl`. Adapts to `HTTPS_ENABLED` and `DOMAIN_NAME` environment variables to handle custom domains and SSL correctly. Returns exit code `1` on failure.